### PR TITLE
Workaround for duckdb parallel cvs reader OoM fault on high #threads

### DIFF
--- a/bin/py/relabel.py
+++ b/bin/py/relabel.py
@@ -24,6 +24,10 @@ def relabel(con, graph, input_vertex_path, input_edge_path, output_path, directe
 
     ## configuration
     con.execute(f"SET experimental_parallel_csv=true")
+    # parallel csv faults on systems with high core counts, workaround is to use only half
+    cpu_count = os.cpu_count()
+    if (cpu_count is not None and cpu_count > 100):
+        con.execute(f"SET threads={cpu_count / 2}")
 
     ## graph tables
     con.execute(f"CREATE OR REPLACE TABLE v (id BIGINT)")


### PR DESCRIPTION
This option in `relabel.py`:
>     con.execute(f"SET experimental_parallel_csv=true")
causes duckdb to throw an out of memory error, even though there is plenty of memory left. It only appears to do this on systems with high core/thread count. Running with reduced thread count no longer produces the error, hence this workaround.

